### PR TITLE
Fix validation for args for unpeg cmd

### DIFF
--- a/x/proximax-bridge/client/cli/tx.go
+++ b/x/proximax-bridge/client/cli/tx.go
@@ -46,7 +46,7 @@ func GetCmdUnpeg(cdc *codec.Codec) *cobra.Command {
 			cliCtx := context.NewCLIContextWithInputAndFrom(inBuf, args[0]).WithCodec(cdc)
 			txBldr := auth.NewTxBuilderFromCLI(inBuf).WithTxEncoder(utils.GetTxEncoder(cdc))
 
-			coins, err := sdk.ParseCoins(args[2])
+			coins, err := sdk.ParseCoins(args[1])
 			if err != nil {
 				return err
 			}
@@ -56,7 +56,7 @@ func GetCmdUnpeg(cdc *codec.Codec) *cobra.Command {
 				return err
 			}
 
-			msg := types.NewMsgUnpeg(cliCtx.GetFromAddress(), args[1], coins, firstCosignerAddress)
+			msg := types.NewMsgUnpeg(cliCtx.GetFromAddress(), args[2], coins, firstCosignerAddress)
 			err = msg.ValidateBasic()
 			if err != nil {
 				return err


### PR DESCRIPTION
unpegコマンドのバリデーション部分で、コマンドライン引数の順番がずれていたので修正

以下のuseで定義されていた順番を基準に、正しい値が参照できるように参照インデックスを修正しました
```
unpeg [key_or_address] [amount] [mainchain_address] [first_cosigner_address]
```

