### PR TITLE
Add Slashing for failed invitation

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -157,7 +157,7 @@ func NewInitApp(
 		gov.StoreKey, params.StoreKey, evidence.StoreKey, upgrade.StoreKey,
 		oracle.StoreKey,
 
-		bridge.StoreKey, bridge.StoreKeyForPeg, bridge.StoreKeyForCosign,
+		bridge.StoreKey, bridge.StoreKeyForPeg, bridge.StoreKeyForCosign, bridge.StoreKeyForInvite,
 	)
 	tKeys := sdk.NewTransientStoreKeys(staking.TStoreKey, params.TStoreKey)
 
@@ -282,7 +282,7 @@ func NewInitApp(
 
 	// TODO: Add your module(s) keepers
 	app.oracleKeeper = oracle.NewKeeper(app.cdc, keys[oracle.StoreKey], app.stakingKeeper, oracle.DefaultConsensusNeeded)
-	app.bridgeKeeper = bridge.NewKeeper(app.cdc, keys[bridge.StoreKey], keys[bridge.StoreKeyForPeg], keys[bridge.StoreKeyForCosign], app.subspaces[bridge.ModuleName], app.supplyKeeper, app.slashingKeeper, app.oracleKeeper)
+	app.bridgeKeeper = bridge.NewKeeper(app.cdc, keys[bridge.StoreKey], keys[bridge.StoreKeyForPeg], keys[bridge.StoreKeyForCosign], keys[bridge.StoreKeyForInvite], app.subspaces[bridge.ModuleName], app.supplyKeeper, app.slashingKeeper, app.oracleKeeper)
 
 	// NOTE: Any module instantiated in the module manager that is later modified
 	// must be passed by reference here.

--- a/cmd/pxbrelayer/txs/parser.go
+++ b/cmd/pxbrelayer/txs/parser.go
@@ -83,7 +83,7 @@ func UnpegEventToCosmosMsg(attributes []tmKv.Pair) (*msgTypes.MsgUnpeg, error) {
 	return &cosmosMsg, nil
 }
 
-func RequestInvitationEventToCosmosMsg(attributes []tmKv.Pair) (*msgTypes.MsgRequestInvitation, error) {
+func RequestInvitationEventToCosmosMsg(attributes []tmKv.Pair) (*msgTypes.MsgRequestInvitation, string, error) {
 	var address sdk.ValAddress
 	var multisigAccountPublicKey string
 	var newCosignerPublicKey string
@@ -94,7 +94,7 @@ func RequestInvitationEventToCosmosMsg(attributes []tmKv.Pair) (*msgTypes.MsgReq
 		key := string(attribute.GetKey())
 		val := string(attribute.GetValue())
 		switch key {
-		case "cosmos_sender":
+		case "cosmos_account":
 			address, err = sdk.ValAddressFromBech32(val)
 			if err != nil {
 				break
@@ -114,8 +114,8 @@ func RequestInvitationEventToCosmosMsg(attributes []tmKv.Pair) (*msgTypes.MsgReq
 		}
 	}
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
-	cosmosMsg := msgTypes.NewMsgRequestInvitation(address, multisigAccountPublicKey, newCosignerPublicKey, firstCosignerAddress)
-	return &cosmosMsg, nil
+	cosmosMsg := msgTypes.NewMsgRequestInvitation(address, newCosignerPublicKey, firstCosignerAddress)
+	return &cosmosMsg, multisigAccountPublicKey, nil
 }

--- a/x/proximax-bridge/alias.go
+++ b/x/proximax-bridge/alias.go
@@ -13,6 +13,7 @@ const (
 	StoreKey          = types.StoreKey
 	StoreKeyForPeg    = types.StoreKeyForPeg
 	StoreKeyForCosign = types.StoreKeyForCosign
+	StoreKeyForInvite = types.StoreKeyForInvite
 	DefaultParamspace = types.DefaultParamspace
 	QuerierRoute      = types.QuerierRoute
 )
@@ -26,14 +27,15 @@ var (
 	DefaultGenesisState = types.DefaultGenesisState
 	ValidateGenesis     = types.ValidateGenesis
 	// TODO: Fill out function aliases
-	NewMsgPeg                        = types.NewMsgPeg
-	NewMsgPegClaim                   = types.NewMsgPegClaim
-	NewMsgUnpeg                      = types.NewMsgUnpeg
-	NewMsgRecordUnpeg                = types.NewMsgRecordUnpeg
-	NewMsgNotifyCosigned             = types.NewMsgNotifyCosigned
-	NewMsgUnpegNotCosignedClaim      = types.NewMsgUnpegNotCosignedClaim
-	NewMsgRequestInvitation          = types.NewMsgRequestInvitation
-	NewMsgInvitationNotCosignedClaim = types.NewMsgMsgInvitationNotCosignedClaim
+	NewMsgPeg                      = types.NewMsgPeg
+	NewMsgPegClaim                 = types.NewMsgPegClaim
+	NewMsgUnpeg                    = types.NewMsgUnpeg
+	NewMsgRecordUnpeg              = types.NewMsgRecordUnpeg
+	NewMsgNotifyCosigned           = types.NewMsgNotifyCosigned
+	NewMsgNotCosignedClaim         = types.NewMsgNotCosignedClaim
+	NewMsgRequestInvitation        = types.NewMsgRequestInvitation
+	NewMsgPendingRequestInvitation = types.NewMsgPendingRequestInvitation
+	NewMsgConfirmedInvitation      = types.NewMsgConfirmedInvitation
 
 	// variable aliases
 	ModuleCdc = types.ModuleCdc
@@ -46,14 +48,15 @@ type (
 	Params       = types.Params
 
 	// TODO: Fill out module types
-	MsgPeg                        = types.MsgPeg
-	MsgPegClaim                   = types.MsgPegClaim
-	MsgUnpeg                      = types.MsgUnpeg
-	MsgRecordUnpeg                = types.MsgRecordUnpeg
-	MsgNotifyCosigned             = types.MsgNotifyCosigned
-	MsgUnpegNotCosignedClaim      = types.MsgUnpegNotCosignedClaim
-	MsgRequestInvitation          = types.MsgRequestInvitation
-	MsgInvitationNotCosignedClaim = types.MsgInvitationNotCosignedClaim
+	MsgPeg                      = types.MsgPeg
+	MsgPegClaim                 = types.MsgPegClaim
+	MsgUnpeg                    = types.MsgUnpeg
+	MsgRecordUnpeg              = types.MsgRecordUnpeg
+	MsgNotifyCosigned           = types.MsgNotifyCosigned
+	MsgNotCosignedClaim         = types.MsgNotCosignedClaim
+	MsgRequestInvitation        = types.MsgRequestInvitation
+	MsgPendingRequestInvitation = types.MsgPendingRequestInvitation
+	MsgConfirmedInvitation      = types.MsgConfirmedInvitation
 
 	Cosigner = types.Cosigner
 )

--- a/x/proximax-bridge/client/cli/tx.go
+++ b/x/proximax-bridge/client/cli/tx.go
@@ -120,20 +120,25 @@ func GetCmdUnpeg(cdc *codec.Codec) *cobra.Command {
 
 func GetCmdRequestInvitation(cdc *codec.Codec) *cobra.Command {
 	return &cobra.Command{
-		Use:   "request-invitation [from_key_or_address] [multisig_account_address] [new_cosigner_public_key] [first_cosigner_address]",
+		Use:   "request-invitation [from_key_or_address] [new_cosigner_public_key] [first_cosigner_address]",
 		Short: "Request invitation for multisig cosigner",
-		Args:  cobra.ExactArgs(4), // Does your request require arguments
+		Args:  cobra.ExactArgs(3), // Does your request require arguments
 		RunE: func(cmd *cobra.Command, args []string) error {
 			inBuf := bufio.NewReader(cmd.InOrStdin())
 			cliCtx := context.NewCLIContextWithInputAndFrom(inBuf, args[0]).WithCodec(cdc)
 			txBldr := auth.NewTxBuilderFromCLI(inBuf).WithTxEncoder(utils.GetTxEncoder(cdc))
 
-			firstCosignerAddress, err := sdk.ValAddressFromBech32(args[3])
+			newCosignerPublicKey := args[1]
+			if len(strings.Trim(newCosignerPublicKey, "")) == 0 {
+				return errors.New(fmt.Sprintf("invalid [new_cosigner_public_key]: %s", newCosignerPublicKey))
+			}
+
+			firstCosignerAddress, err := sdk.ValAddressFromBech32(args[2])
 			if err != nil {
 				return err
 			}
 
-			msg := types.NewMsgRequestInvitation(sdk.ValAddress(cliCtx.FromAddress), args[1], args[2], firstCosignerAddress)
+			msg := types.NewMsgRequestInvitation(sdk.ValAddress(cliCtx.FromAddress), newCosignerPublicKey, firstCosignerAddress)
 			err = msg.ValidateBasic()
 			if err != nil {
 				return err

--- a/x/proximax-bridge/client/rest/tx.go
+++ b/x/proximax-bridge/client/rest/tx.go
@@ -61,7 +61,6 @@ type RequestInvitationReq struct {
 	BaseReq rest.BaseReq `json:"base_req" yaml:"base_req"`
 	// TODO: Define more types if needed
 	Address              string `json:"address" yaml:"address"`
-	MainchainAddress     string `json:"mainchain_address" yaml:"mainchain_address"`
 	NewCosignerPublicKey string `json:"new_cosigner_public_key" yaml:"new_cosigner_public_key"`
 	FirstCosignerAddress string `json:"first_cosigner_address" yaml:"first_cosigner_address"`
 }
@@ -81,7 +80,6 @@ func RequestInvitationRequestHandlerFn(cliCtx context.CLIContext) http.HandlerFu
 		// TODO: Define the module tx logic for this action
 		msg := types.NewMsgRequestInvitation(
 			address,
-			req.MainchainAddress,
 			req.NewCosignerPublicKey,
 			firstCosignerAddress,
 		)

--- a/x/proximax-bridge/handler.go
+++ b/x/proximax-bridge/handler.go
@@ -16,6 +16,7 @@ import (
 func NewHandler(cdc *codec.Codec, accountKeeper auth.AccountKeeper, bridgeKeeper Keeper) sdk.Handler {
 	return func(ctx sdk.Context, msg sdk.Msg) (*sdk.Result, error) {
 		ctx = ctx.WithEventManager(sdk.NewEventManager())
+
 		switch msg := msg.(type) {
 		// TODO: Define your msg cases
 		//
@@ -30,15 +31,20 @@ func NewHandler(cdc *codec.Codec, accountKeeper auth.AccountKeeper, bridgeKeeper
 			return handleMsgRecordUnpeg(ctx, cdc, bridgeKeeper, msg)
 		case MsgNotifyCosigned:
 			return handleMsgNotifyCosigned(ctx, cdc, bridgeKeeper, msg)
-		case MsgUnpegNotCosignedClaim:
-			return handleMsgUnpegNotCosignedClaim(ctx, cdc, accountKeeper, bridgeKeeper, msg)
 		case MsgRequestInvitation:
-			return handleMsgRequestInvitation(ctx, cdc, msg)
+			return handleMsgRequestInvitation(ctx, cdc, bridgeKeeper, msg)
+		case MsgPendingRequestInvitation:
+			return handleMsgPendingRequestInvitation(ctx, cdc, bridgeKeeper, msg)
+		case MsgConfirmedInvitation:
+			return handleMsgConfirmedInvitation(ctx, cdc, bridgeKeeper, msg)
+		case MsgNotCosignedClaim:
+			return handleMsgNotCosignedClaim(ctx, cdc, accountKeeper, bridgeKeeper, msg)
 
 		//Example:
 		// case MsgSet<Action>:
 		// 	return handleMsg<Action>(ctx, keeper, msg)
 		default:
+			fmt.Printf("Msg10: %+v %s\n", msg, msg.Type())
 			errMsg := fmt.Sprintf("unrecognized %s message type: %T", types.ModuleName, msg)
 			return nil, sdkerrors.Wrap(sdkerrors.ErrUnknownRequest, errMsg)
 		}
@@ -147,16 +153,73 @@ func handleMsgNotifyCosigned(ctx sdk.Context, cdc *codec.Codec, bridgeKeeper Kee
 	return &sdk.Result{Events: ctx.EventManager().Events()}, nil
 }
 
-func handleMsgUnpegNotCosignedClaim(
-	ctx sdk.Context, cdc *codec.Codec, accountKeeper auth.AccountKeeper,
-	bridgeKeeper Keeper, msg MsgUnpegNotCosignedClaim,
+func handleMsgRequestInvitation(
+	ctx sdk.Context, cdc *codec.Codec, bridgeKeeper Keeper, msg MsgRequestInvitation,
 ) (*sdk.Result, error) {
-	status, err := bridgeKeeper.ProcessUnpegNotCosignedClaim(ctx, msg)
+	param := bridgeKeeper.GetParams(ctx)
+
+	ctx.EventManager().EmitEvents(sdk.Events{
+		sdk.NewEvent(
+			sdk.EventTypeMessage,
+			sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
+			sdk.NewAttribute(sdk.AttributeKeySender, msg.Address.String()),
+		),
+		sdk.NewEvent(
+			types.EventTypeInvitation,
+			sdk.NewAttribute(types.AttributeKeyCosmosAccount, msg.Address.String()),
+			sdk.NewAttribute(types.AttributeKeyMultisigAccountAddress, param.MainchainMultisigAddress),
+			sdk.NewAttribute(types.AttributeKeyNewCosignerPublicKey, msg.NewCosignerPublicKey),
+			sdk.NewAttribute(types.AttributeKeyFirstCosignerAddress, msg.FirstCosignerAddress.String()),
+		),
+	})
+	return &sdk.Result{Events: ctx.EventManager().Events()}, nil
+}
+
+func handleMsgPendingRequestInvitation(
+	ctx sdk.Context, cdc *codec.Codec, bridgeKeeper Keeper, msg MsgPendingRequestInvitation,
+) (*sdk.Result, error) {
+	fmt.Printf("handleMsgPendingRequestInvitation %+v\n", msg)
+	bridgeKeeper.SetPendingInviteRequest(ctx, msg.TxHash, msg.Address, msg.NewCosignerPublicKey)
+	bridgeKeeper.SetCosigners(ctx, msg.TxHash, msg.FirstCosignerPublicKey)
+
+	ctx.EventManager().EmitEvents(sdk.Events{
+		sdk.NewEvent(
+			sdk.EventTypeMessage,
+			sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
+			sdk.NewAttribute(sdk.AttributeKeySender, msg.Address.String()),
+		),
+	})
+	return &sdk.Result{Events: ctx.EventManager().Events()}, nil
+}
+
+func handleMsgConfirmedInvitation(
+	ctx sdk.Context, cdc *codec.Codec, bridgeKeeper Keeper, msg MsgConfirmedInvitation,
+) (*sdk.Result, error) {
+	request, err := bridgeKeeper.GetPendingRequest(ctx, msg.TxHash)
+	if err != nil {
+		bridgeKeeper.AddNewCosigner(ctx, request.Address, request.MainchainPublicKey)
+	}
+
+	ctx.EventManager().EmitEvents(sdk.Events{
+		sdk.NewEvent(
+			sdk.EventTypeMessage,
+			sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
+			sdk.NewAttribute(sdk.AttributeKeySender, msg.Address.String()),
+		),
+	})
+	return &sdk.Result{Events: ctx.EventManager().Events()}, nil
+}
+
+func handleMsgNotCosignedClaim(
+	ctx sdk.Context, cdc *codec.Codec, accountKeeper auth.AccountKeeper,
+	bridgeKeeper Keeper, msg MsgNotCosignedClaim,
+) (*sdk.Result, error) {
+	status, err := bridgeKeeper.ProcessNotCosignedClaim(ctx, msg)
 	if err != nil {
 		return nil, err
 	}
 	if status.Text == oracle.SuccessStatusText {
-		if err := bridgeKeeper.ProcessSuccessfulUnpegNotCosignedClaim(ctx, status.FinalClaim); err != nil {
+		if err := bridgeKeeper.ProcessSuccessfulNotCosignedClaim(ctx, status.FinalClaim); err != nil {
 			return nil, err
 		}
 	}
@@ -171,24 +234,4 @@ func handleMsgUnpegNotCosignedClaim(
 
 	return &sdk.Result{Events: ctx.EventManager().Events()}, nil
 
-}
-
-func handleMsgRequestInvitation(
-	ctx sdk.Context, cdc *codec.Codec, msg MsgRequestInvitation,
-) (*sdk.Result, error) {
-	ctx.EventManager().EmitEvents(sdk.Events{
-		sdk.NewEvent(
-			sdk.EventTypeMessage,
-			sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-			sdk.NewAttribute(sdk.AttributeKeySender, msg.Address.String()),
-		),
-		sdk.NewEvent(
-			types.EventTypeInvitation,
-			sdk.NewAttribute(types.AttributeKeyCosmosSender, msg.Address.String()),
-			sdk.NewAttribute(types.AttributeKeyMultisigAccountAddress, msg.MultisigAccountAddress),
-			sdk.NewAttribute(types.AttributeKeyNewCosignerPublicKey, msg.NewCosignerPublicKey),
-			sdk.NewAttribute(types.AttributeKeyFirstCosignerAddress, msg.FirstCosignerAddress.String()),
-		),
-	})
-	return &sdk.Result{Events: ctx.EventManager().Events()}, nil
 }

--- a/x/proximax-bridge/internal/keeper/params.go
+++ b/x/proximax-bridge/internal/keeper/params.go
@@ -17,3 +17,15 @@ func (k Keeper) GetParams(ctx sdk.Context) (params types.Params) {
 func (k Keeper) SetParams(ctx sdk.Context, params types.Params) {
 	k.paramspace.SetParamSet(ctx, &params)
 }
+
+func (k Keeper) AddNewCosigner(ctx sdk.Context, address sdk.ValAddress, mainchainPublicKey string) {
+	params := k.GetParams(ctx)
+
+	for _, cosigner := range params.Cosigners {
+		if cosigner.MainchainPublicKey == mainchainPublicKey {
+			return
+		}
+	}
+	params.Cosigners = append(params.Cosigners, types.Cosigner{ValidatorAddress: address.String(), MainchainPublicKey: mainchainPublicKey})
+	k.SetParams(ctx, params)
+}

--- a/x/proximax-bridge/internal/types/claim.go
+++ b/x/proximax-bridge/internal/types/claim.go
@@ -20,18 +20,7 @@ func CreateOracleClaimFromMsgPegClaim(cdc *codec.Codec, msg MsgPegClaim) (oracle
 	return claim, nil
 }
 
-func CreateOracleClaimFromMsgUnpegNotCosignedClaim(cdc *codec.Codec, msg MsgUnpegNotCosignedClaim) (oracle.Claim, error) {
-	oracleID := msg.TxHash
-	claimBytes, err := json.Marshal(msg)
-	if err != nil {
-		return oracle.Claim{}, err
-	}
-	claimString := string(claimBytes)
-	claim := oracle.NewClaim(oracleID, msg.Address, claimString)
-	return claim, nil
-}
-
-func CreateOracleClaimFromMsgInvitationNotCosignedClaim(cdc *codec.Codec, msg MsgInvitationNotCosignedClaim) (oracle.Claim, error) {
+func CreateOracleClaimFromMsgNotCosignedClaim(cdc *codec.Codec, msg MsgNotCosignedClaim) (oracle.Claim, error) {
 	oracleID := msg.TxHash
 	claimBytes, err := json.Marshal(msg)
 	if err != nil {
@@ -59,26 +48,12 @@ func CreateMsgPegClaimFromOracleString(oracleClaimString string) (MsgPegClaim, e
 // CreateOracleClaimFromOracleString converts a JSON string into an OracleClaimContent struct used by this module.
 // In general, it is expected that the oracle module will store claims in this JSON format
 // and so this should be used to convert oracle claims.
-func CreateMsgUnpegNotCosignedClaimFromOracleString(oracleClaimString string) (MsgUnpegNotCosignedClaim, error) {
-	var oracleClaim MsgUnpegNotCosignedClaim
+func CreateMsgNotCosignedClaimFromOracleString(oracleClaimString string) (MsgNotCosignedClaim, error) {
+	var oracleClaim MsgNotCosignedClaim
 
 	bz := []byte(oracleClaimString)
 	if err := json.Unmarshal(bz, &oracleClaim); err != nil {
-		return MsgUnpegNotCosignedClaim{}, sdkerrors.Wrap(ErrJSONMarshalling, fmt.Sprintf("failed to parse claim: %s", err.Error()))
-	}
-
-	return oracleClaim, nil
-}
-
-// CreateOracleClaimFromOracleString converts a JSON string into an OracleClaimContent struct used by this module.
-// In general, it is expected that the oracle module will store claims in this JSON format
-// and so this should be used to convert oracle claims.
-func CreateMsgInvitationNotCosignedClaimFromOracleString(oracleClaimString string) (MsgInvitationNotCosignedClaim, error) {
-	var oracleClaim MsgInvitationNotCosignedClaim
-
-	bz := []byte(oracleClaimString)
-	if err := json.Unmarshal(bz, &oracleClaim); err != nil {
-		return MsgInvitationNotCosignedClaim{}, sdkerrors.Wrap(ErrJSONMarshalling, fmt.Sprintf("failed to parse claim: %s", err.Error()))
+		return MsgNotCosignedClaim{}, sdkerrors.Wrap(ErrJSONMarshalling, fmt.Sprintf("failed to parse claim: %s", err.Error()))
 	}
 
 	return oracleClaim, nil

--- a/x/proximax-bridge/internal/types/codec.go
+++ b/x/proximax-bridge/internal/types/codec.go
@@ -13,7 +13,9 @@ func RegisterCodec(cdc *codec.Codec) {
 	cdc.RegisterConcrete(MsgRecordUnpeg{}, "proximaxbridge/MsgRecordUnpeg", nil)
 	cdc.RegisterConcrete(MsgNotifyCosigned{}, "proximaxbridge/MsgNotifyCosigned", nil)
 	cdc.RegisterConcrete(MsgRequestInvitation{}, "proximaxbridge/MsgRequestInvitation", nil)
-	cdc.RegisterConcrete(MsgUnpegNotCosignedClaim{}, "proximaxbridge/MsgUnpegNotCosignedClaim", nil)
+	cdc.RegisterConcrete(MsgPendingRequestInvitation{}, "proximaxbridge/MsgPendingRequestInvitation", nil)
+	cdc.RegisterConcrete(MsgConfirmedInvitation{}, "proximaxbridge/MsgConfirmedInvitation", nil)
+	cdc.RegisterConcrete(MsgNotCosignedClaim{}, "proximaxbridge/MsgNotCosignedClaim", nil)
 }
 
 // ModuleCdc defines the module codec

--- a/x/proximax-bridge/internal/types/key.go
+++ b/x/proximax-bridge/internal/types/key.go
@@ -11,6 +11,8 @@ const (
 
 	StoreKeyForCosign = ModuleName + "_cosign"
 
+	StoreKeyForInvite = ModuleName + "_invite"
+
 	// RouterKey to be used for routing msgs
 	RouterKey = ModuleName
 

--- a/x/proximax-bridge/internal/types/msg.go
+++ b/x/proximax-bridge/internal/types/msg.go
@@ -231,39 +231,39 @@ func (msg MsgNotifyCosigned) ValidateBasic() error {
 
 // TODO: Describe your actions, these will implment the interface of `sdk.Msg`
 // verify interface at compile time
-var _ sdk.Msg = &MsgUnpegNotCosignedClaim{}
+var _ sdk.Msg = &MsgNotCosignedClaim{}
 
-// MsgUnpegNotCosignedClaim - struct for unjailing jailed validator
-type MsgUnpegNotCosignedClaim struct {
+// MsgNotCosignedClaim - struct for unjailing jailed validator
+type MsgNotCosignedClaim struct {
 	Address sdk.ValAddress `json:"address" yaml:"address"`
 	TxHash  string         `json:"tx_hash" yaml:"tx_hash"`
 }
 
-// NewMsgUnpegNotCosignedClaim creates a new MsgUnpegNotCosignedClaim instance
-func NewMsgUnpegNotCosignedClaim(address sdk.ValAddress, txHash string) MsgUnpegNotCosignedClaim {
-	return MsgUnpegNotCosignedClaim{
+// NewMsgNotCosignedClaim creates a new MsgNotCosignedClaim instance
+func NewMsgNotCosignedClaim(address sdk.ValAddress, txHash string) MsgNotCosignedClaim {
+	return MsgNotCosignedClaim{
 		Address: address,
 		TxHash:  txHash,
 	}
 }
 
-const unpegNotCosignedClaimConst = "unpeg_not_cosigned_claim"
+const notCosignedClaimConst = "not_cosigned_claim"
 
 // nolint
-func (msg MsgUnpegNotCosignedClaim) Route() string { return RouterKey }
-func (msg MsgUnpegNotCosignedClaim) Type() string  { return unpegNotCosignedClaimConst }
-func (msg MsgUnpegNotCosignedClaim) GetSigners() []sdk.AccAddress {
+func (msg MsgNotCosignedClaim) Route() string { return RouterKey }
+func (msg MsgNotCosignedClaim) Type() string  { return notCosignedClaimConst }
+func (msg MsgNotCosignedClaim) GetSigners() []sdk.AccAddress {
 	return []sdk.AccAddress{sdk.AccAddress(msg.Address)}
 }
 
 // GetSignBytes gets the bytes for the message signer to sign on
-func (msg MsgUnpegNotCosignedClaim) GetSignBytes() []byte {
+func (msg MsgNotCosignedClaim) GetSignBytes() []byte {
 	bz := ModuleCdc.MustMarshalJSON(msg)
 	return sdk.MustSortJSON(bz)
 }
 
 // ValidateBasic validity check for the AnteHandler
-func (msg MsgUnpegNotCosignedClaim) ValidateBasic() error {
+func (msg MsgNotCosignedClaim) ValidateBasic() error {
 	if msg.Address.Empty() {
 		return sdkerrors.Wrap(sdkerrors.ErrInvalidAddress, "missing validator address")
 	}
@@ -277,19 +277,17 @@ var _ sdk.Msg = &MsgRequestInvitation{}
 
 // MsgRequestInvitation - struct for unjailing jailed validator
 type MsgRequestInvitation struct {
-	Address                sdk.ValAddress `json:"address" yaml:"address"`
-	MultisigAccountAddress string         `json:"multisig_account_address" yaml:"multisig_account_address"`
-	NewCosignerPublicKey   string         `json:"new_cosigner_public_key" yaml:"new_cosigner_public_key"`
-	FirstCosignerAddress   sdk.ValAddress `json:"first_cosigner_address" yaml:"first_cosigner_address"`
+	Address              sdk.ValAddress `json:"address" yaml:"address"`
+	NewCosignerPublicKey string         `json:"new_cosigner_public_key" yaml:"new_cosigner_public_key"`
+	FirstCosignerAddress sdk.ValAddress `json:"first_cosigner_address" yaml:"first_cosigner_address"`
 }
 
 // NewMsgRequestInvitation creates a new MsgRequestInvitation instance
-func NewMsgRequestInvitation(address sdk.ValAddress, multisigAccountAddress, newCosignerPublicKey string, firstCosignerAddress sdk.ValAddress) MsgRequestInvitation {
+func NewMsgRequestInvitation(address sdk.ValAddress, newCosignerPublicKey string, firstCosignerAddress sdk.ValAddress) MsgRequestInvitation {
 	return MsgRequestInvitation{
-		Address:                address,
-		MultisigAccountAddress: multisigAccountAddress,
-		NewCosignerPublicKey:   newCosignerPublicKey,
-		FirstCosignerAddress:   firstCosignerAddress,
+		Address:              address,
+		NewCosignerPublicKey: newCosignerPublicKey,
+		FirstCosignerAddress: firstCosignerAddress,
 	}
 }
 
@@ -316,44 +314,126 @@ func (msg MsgRequestInvitation) ValidateBasic() error {
 	return nil
 }
 
-// TODO: Describe your actions, these will implment the interface of `sdk.Msg`
+var _ sdk.Msg = &MsgPendingRequestInvitation{}
 
-// verify interface at compile time
-var _ sdk.Msg = &MsgInvitationNotCosignedClaim{}
-
-// MsgInvitationNotCosignedClaim - struct for unjailing jailed validator
-type MsgInvitationNotCosignedClaim struct {
-	Address               sdk.ValAddress `json:"address" yaml:"address"`
-	TxHash                string         `json:"tx_hash" yaml:"tx_hash"`
-	NotCosignedValidators []string       `json:"not_cosigned_validators" yaml:"not_cosigned_validators"`
+// MsgRequestInvitation - struct for unjailing jailed validator
+type MsgPendingRequestInvitation struct {
+	Address                sdk.ValAddress `json:"address" yaml:"address"`
+	NewCosignerPublicKey   string         `json:"new_cosigner_public_key" yaml:"new_cosigner_public_key"`
+	FirstCosignerAddress   sdk.ValAddress `json:"first_cosigner_address" yaml:"first_cosigner_address"`
+	FirstCosignerPublicKey string         `json:"first_cosigner_public_key" yaml:"first_cosigner_public_key"`
+	TxHash                 string         `json:"tx_hash" yaml:"tx_hash"`
 }
 
-// NewMsgMsgInvitationNotCosignedClaim creates a new MsgMsgInvitationNotCosignedClaim instance
-func NewMsgMsgInvitationNotCosignedClaim(address sdk.ValAddress, txHash string, notCosignedValidators []string) MsgInvitationNotCosignedClaim {
-	return MsgInvitationNotCosignedClaim{
-		Address:               address,
-		TxHash:                txHash,
-		NotCosignedValidators: notCosignedValidators,
+// NewMsgRequestInvitation creates a new MsgRequestInvitation instance
+func NewMsgPendingRequestInvitation(address sdk.ValAddress, newCosignerPublicKey string, firstCosignerAddress sdk.ValAddress, firstCosignerPublicKey, txHash string) MsgPendingRequestInvitation {
+	return MsgPendingRequestInvitation{
+		Address:                address,
+		NewCosignerPublicKey:   newCosignerPublicKey,
+		FirstCosignerAddress:   firstCosignerAddress,
+		FirstCosignerPublicKey: firstCosignerPublicKey,
+		TxHash:                 txHash,
 	}
 }
 
-const invitationNotCosignedClaimConst = "invitation_not_cosigned_claim"
+const pendingRequestInvitationConst = "pending_request_invitation"
 
 // nolint
-func (msg MsgInvitationNotCosignedClaim) Route() string { return RouterKey }
-func (msg MsgInvitationNotCosignedClaim) Type() string  { return invitationNotCosignedClaimConst }
-func (msg MsgInvitationNotCosignedClaim) GetSigners() []sdk.AccAddress {
-	return []sdk.AccAddress{sdk.AccAddress(msg.Address)}
+func (msg MsgPendingRequestInvitation) Route() string { return RouterKey }
+func (msg MsgPendingRequestInvitation) Type() string  { return pendingRequestInvitationConst }
+func (msg MsgPendingRequestInvitation) GetSigners() []sdk.AccAddress {
+	return []sdk.AccAddress{sdk.AccAddress(msg.FirstCosignerAddress)}
 }
 
 // GetSignBytes gets the bytes for the message signer to sign on
-func (msg MsgInvitationNotCosignedClaim) GetSignBytes() []byte {
+func (msg MsgPendingRequestInvitation) GetSignBytes() []byte {
 	bz := ModuleCdc.MustMarshalJSON(msg)
 	return sdk.MustSortJSON(bz)
 }
 
 // ValidateBasic validity check for the AnteHandler
-func (msg MsgInvitationNotCosignedClaim) ValidateBasic() error {
+func (msg MsgPendingRequestInvitation) ValidateBasic() error {
+	if msg.Address.Empty() {
+		return sdkerrors.Wrap(sdkerrors.ErrInvalidAddress, "missing validator address")
+	}
+	return nil
+}
+
+var _ sdk.Msg = &MsgNewCosignerInvited{}
+
+// MsgProximaXTransactionStatus - struct for unjailing jailed validator
+type MsgNewCosignerInvited struct {
+	Address            sdk.ValAddress `json:"address" yaml:"address"`
+	TxHash             string         `json:"mainchain_tx_hash" yaml:"mainchain_tx_hash"`
+	MainchainPublicKey string         `json:"mainchain_public_key" yaml:"mainchain_public_key"`
+}
+
+// NewMsgRequestInvitation creates a new MsgRequestInvitation instance
+func NewMsgNewCosignerInvited(address sdk.ValAddress, txHash, pubKey string) MsgNewCosignerInvited {
+	return MsgNewCosignerInvited{
+		Address:            address,
+		TxHash:             txHash,
+		MainchainPublicKey: pubKey,
+	}
+}
+
+const newCosignerInvitedConst = "new_cosigner_invited"
+
+// nolint
+func (msg MsgNewCosignerInvited) Route() string { return RouterKey }
+func (msg MsgNewCosignerInvited) Type() string  { return newCosignerInvitedConst }
+func (msg MsgNewCosignerInvited) GetSigners() []sdk.AccAddress {
+	return []sdk.AccAddress{sdk.AccAddress(msg.Address)}
+}
+
+// GetSignBytes gets the bytes for the message signer to sign on
+func (msg MsgNewCosignerInvited) GetSignBytes() []byte {
+	bz := ModuleCdc.MustMarshalJSON(msg)
+	return sdk.MustSortJSON(bz)
+}
+
+// ValidateBasic validity check for the AnteHandler
+func (msg MsgNewCosignerInvited) ValidateBasic() error {
+	if msg.Address.Empty() {
+		return sdkerrors.Wrap(sdkerrors.ErrInvalidAddress, "missing validator address")
+	}
+	return nil
+}
+
+//hoge
+var _ sdk.Msg = &MsgConfirmedInvitation{}
+
+// MsgProximaXTransactionStatus - struct for unjailing jailed validator
+type MsgConfirmedInvitation struct {
+	Address sdk.ValAddress `json:"address" yaml:"address"`
+	TxHash  string         `json:"mainchain_tx_hash" yaml:"mainchain_tx_hash"`
+}
+
+// NewMsgRequestInvitation creates a new MsgRequestInvitation instance
+func NewMsgConfirmedInvitation(address sdk.ValAddress, txHash string) MsgConfirmedInvitation {
+	return MsgConfirmedInvitation{
+		Address: address,
+		TxHash:  txHash,
+	}
+}
+
+const confirmedInvitationConst = "confirmed_invitation"
+
+// nolint
+func (msg MsgConfirmedInvitation) Route() string { return RouterKey }
+func (msg MsgConfirmedInvitation) Type() string  { return confirmedInvitationConst }
+func (msg MsgConfirmedInvitation) GetSigners() []sdk.AccAddress {
+	return []sdk.AccAddress{sdk.AccAddress(msg.Address)}
+}
+
+// GetSignBytes gets the bytes for the message signer to sign on
+func (msg MsgConfirmedInvitation) GetSignBytes() []byte {
+	bz := ModuleCdc.MustMarshalJSON(msg)
+	return sdk.MustSortJSON(bz)
+}
+
+// ValidateBasic validity check for the AnteHandler
+func (msg MsgConfirmedInvitation) ValidateBasic() error {
 	if msg.Address.Empty() {
 		return sdkerrors.Wrap(sdkerrors.ErrInvalidAddress, "missing validator address")
 	}


### PR DESCRIPTION
Request Invitationが失敗した時に署名しなかったアカウントにSlashできる様に、msg, store, handlerの追加
また、Request Invitationが成功時にParamのCosignerリストにアドレスを追加する様にコードを追加