### PR TITLE
Unify relayer

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,18 +48,13 @@ pxbd start
 
 ```shell
 # Relayer for Cosmos
-pxbrelayer init cosmos [URL for node by RPC] [URL for ProximaX node] [Validator Name] [ProximaX Cosigner Private Key] [ProximaX Multisig Account Public Key] --chain-id=[ChainID]
-
-# Relayer for ProximaX
-pxbrelayer init proximax [URL for node by RPC] [URL for ProximaX node] [Validator Name] [ProximaX Cosigner Private Key] [ProximaX Multisig Account Public Key] --chain-id=[ChainID]
+pxbrelayer start [URL for node by RPC] [URL for ProximaX node] [Validator Name] [ProximaX Cosigner Private Key] [ProximaX Multisig Account Public Key] --chain-id=[ChainID]
 ```
 
 Example
 
 ```shell
-pxbrelayer init cosmos http://127.0.0.1:26657 http://bctestnet1.brimstone.xpxsirius.io:3000 validator1  8611AF477E001C9D033216F94328BD22F91E782FD2D104FAE3F5B66997579154 8007692AB57547661CD0721FBE18AA1DB27E0CC55921D4C0C9A3BEBC96221AC7 --chain-id=testing --rpc-url=http://127.0.0.1:26657
-
-pxbrelayer init proximax http://127.0.0.1:26657 http://bctestnet1.brimstone.xpxsirius.io:3000 validator 8611AF477E001C9D033216F94328BD22F91E782FD2D104FAE3F5B66997579154 VBK6ZOVHKSJOFUOX7XUHHZUABO4Q33GCF726AKHG --chain-id=testing
+pxbrelayer start http://127.0.0.1:26657 http://bctestnet1.brimstone.xpxsirius.io:3000 validator1  8611AF477E001C9D033216F94328BD22F91E782FD2D104FAE3F5B66997579154 8007692AB57547661CD0721FBE18AA1DB27E0CC55921D4C0C9A3BEBC96221AC7 --chain-id=testing --rpc-url=http://127.0.0.1:26657
 ```
 
 ## Test Locally with Multiple nodes by docker-compose

--- a/cmd/pxbrelayer/main.go
+++ b/cmd/pxbrelayer/main.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"log"
-	"net/url"
 	"os"
 	"os/signal"
 	"strings"
@@ -17,6 +16,8 @@ import (
 	"github.com/spf13/viper"
 
 	"github.com/cosmos/cosmos-sdk/client/flags"
+	"github.com/cosmos/cosmos-sdk/x/auth/client/utils"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	amino "github.com/tendermint/go-amino"
 
 	"github.com/cosmos/cosmos-sdk/client/rpc"
@@ -49,17 +50,10 @@ func init() {
 		return initConfig(rootCmd)
 	}
 
-	// Construct Initialization Commands
-	initCmd.AddCommand(
-		proximaxRelayerCmd(),
-		flags.LineBreak,
-		cosmosRelayerCmd(),
-	)
-
 	// Construct Root Command
 	rootCmd.AddCommand(
 		rpc.StatusCommand(),
-		initCmd,
+		relayerCmd(),
 	)
 
 	executor := cli.PrepareMainCmd(rootCmd, "PXB", DefaultCLIHome)
@@ -75,37 +69,19 @@ var rootCmd = &cobra.Command{
 	SilenceUsage: true,
 }
 
-var initCmd = &cobra.Command{
-	Use:   "init",
-	Short: "Initialization subcommands",
-}
-
-func proximaxRelayerCmd() *cobra.Command {
-	ethereumRelayerCmd := &cobra.Command{
-		Use:     "proximax init [tendermint_node] [proximax_node] [validator_from_name] [proximax_private_key] [proximax_multisig_address] --chain-id [chain-id]",
+func relayerCmd() *cobra.Command {
+	relayerCmd := &cobra.Command{
+		Use:     "start [tendermint_node] [proximax_node] [validator_from_name] [proximax_private_key] [proximax_multisig_publickey] --chain-id [chain-id]",
 		Short:   "Initializes a web socket which streams live events from the ProximaX network and relays them to the Cosmos network",
 		Args:    cobra.ExactArgs(5),
-		Example: "pxbrelayer init proximax validator http://localhost:7475 http://bctestnet1.brimstone.xpxsirius.io:3000 3A700AE4105431BB0F24440AAA0CD08E1FD0D87D60EB805278F7DB3EA7C7D62D VBK6ZOASJSJOFUOX7XUHHZVCBO4Q11GCF726AKHG --chain-id=testing",
-		RunE:    RunProximaxRelayerCmd,
+		Example: "pxbrelayer start validator http://localhost:7475 http://bctestnet1.brimstone.xpxsirius.io:3000 3A700AE4105431BB0F24440AAA0CD08E1FD0D87D60EB805278F7DB3EA7C7D62D VBK6ZOASJSJOFUOX7XUHHZVCBO4Q11GCF726AKHG --chain-id=testing",
+		RunE:    RunRelayerCmd,
 	}
 
-	return ethereumRelayerCmd
+	return relayerCmd
 }
 
-func cosmosRelayerCmd() *cobra.Command {
-	cosmosRelayerCmd := &cobra.Command{
-		Use:     "cosmos init [tendermint_node] [proximax_node] [validator_from_name] [proximax_cosigner_private_key] [multisig_account_public_key] --chain-id [chain-id]",
-		Short:   "Initializes a web socket which streams live events from the Cosmos network and relays them to the ProximaX network",
-		Args:    cobra.ExactArgs(5),
-		Example: "pxbrelayer init cosmos tcp://localhost:26657 http://localhost:7545 --chain-id=testing",
-		RunE:    RunCosmosRelayerCmd,
-	}
-
-	return cosmosRelayerCmd
-}
-
-// RunProximaxRelayerCmd executes the initProximaxRelayerCmd with the provided parameters
-func RunProximaxRelayerCmd(cmd *cobra.Command, args []string) error {
+func RunRelayerCmd(cmd *cobra.Command, args []string) error {
 	chainID := viper.GetString(flags.FlagChainID)
 	if strings.TrimSpace(chainID) == "" {
 		return errors.New("Must specify a 'chain-id'")
@@ -126,61 +102,34 @@ func RunProximaxRelayerCmd(cmd *cobra.Command, args []string) error {
 		return errors.New(fmt.Sprintf("invalid [validator_from_name]: %s", validatorMoniker))
 	}
 
-	proximaXCosignerPrivateKey := args[3]
-	if len(strings.Trim(proximaXCosignerPrivateKey, "")) == 0 {
-		return errors.New(fmt.Sprintf("invalid [proximax_private_key]: %s", proximaXCosignerPrivateKey))
-	}
-
-	proximaXMultisigPublicKey := args[4]
-	if len(strings.Trim(proximaXMultisigPublicKey, "")) == 0 {
-		return errors.New(fmt.Sprintf("invalid [proximax_multisig_address]: %s", proximaXMultisigPublicKey))
-	}
-
-	inBuf := bufio.NewReader(cmd.InOrStdin())
-	logger := tmLog.NewTMLogger(tmLog.NewSyncWriter(os.Stdout))
-
-	return relayer.InitProximaXRelayer(inBuf, appCodec, logger, tendermintNode, chainID, validatorMoniker, proximaXNode, proximaXCosignerPrivateKey, proximaXMultisigPublicKey)
-}
-
-// RunCosmosRelayerCmd executes the initCosmosRelayerCmd with the provided parameters
-func RunCosmosRelayerCmd(cmd *cobra.Command, args []string) error {
-	chainID := viper.GetString(flags.FlagChainID)
-	if strings.TrimSpace(chainID) == "" {
-		return errors.New("Must specify a 'chain-id'")
-	}
-
-	tendermintNode := args[0]
-	if len(strings.Trim(tendermintNode, "")) == 0 {
-		return errors.New(fmt.Sprintf("invalid [tendermint-node]: %s", tendermintNode))
-	}
-
-	proximaXNode := args[1]
-	if len(strings.Trim(proximaXNode, "")) > 0 {
-		_, err := url.Parse(proximaXNode)
-		if proximaXNode != "" && err != nil {
-			return errors.New(fmt.Sprintf("invalid ProximaX URL: %v", proximaXNode))
-		}
-	}
-
-	validatorMoniker := args[2]
-	if len(strings.Trim(validatorMoniker, "")) == 0 {
-		return errors.New(fmt.Sprintf("invalid [validator_from_name]: %s", validatorMoniker))
-	}
-
 	cosignerPrivateKey := args[3]
 	if len(strings.Trim(cosignerPrivateKey, "")) == 0 {
-		return errors.New(fmt.Sprintf("invalid [proximax_cosigner_private_key]: %s", cosignerPrivateKey))
+		return errors.New(fmt.Sprintf("invalid [proximax_private_key]: %s", cosignerPrivateKey))
 	}
 
-	multisigPubicKey := args[4]
-	if len(strings.Trim(multisigPubicKey, "")) == 0 {
-		return errors.New(fmt.Sprintf("invalid [multisig_account_public_key]: %s", multisigPubicKey))
+	multisigPublicKey := args[4]
+	if len(strings.Trim(multisigPublicKey, "")) == 0 {
+		return errors.New(fmt.Sprintf("invalid [proximax_multisig_address]: %s", multisigPublicKey))
 	}
-
-	logger := tmLog.NewTMLogger(tmLog.NewSyncWriter(os.Stdout))
 
 	inBuf := bufio.NewReader(cmd.InOrStdin())
-	cosmosSub, err := relayer.NewCosmosSub(inBuf, appCodec, logger, chainID, validatorMoniker, tendermintNode, proximaXNode, cosignerPrivateKey, multisigPubicKey)
+	logger := tmLog.NewTMLogger(tmLog.NewSyncWriter(os.Stdout))
+
+	validatorAddress, validatorName, err := relayer.LoadValidatorCredentials(validatorMoniker, inBuf)
+	if err != nil {
+		return err
+	}
+
+	cliCtx := relayer.LoadTendermintCLIContext(appCodec, validatorAddress, validatorName, tendermintNode, chainID)
+	txBldr := authtypes.NewTxBuilderFromCLI(nil).
+		WithTxEncoder(utils.GetTxEncoder(appCodec)).
+		WithChainID(chainID)
+
+	proximaXSub, err := relayer.NewProximaxSub(appCodec, cliCtx, txBldr, logger, chainID, validatorMoniker, validatorAddress, proximaXNode, cosignerPrivateKey, multisigPublicKey)
+	if err != nil {
+		return err
+	}
+	cosmosSub, err := relayer.NewCosmosSub(appCodec, cliCtx, txBldr, logger, tendermintNode, chainID, validatorMoniker, validatorAddress, proximaXNode, cosignerPrivateKey, multisigPublicKey)
 	if err != nil {
 		return err
 	}
@@ -188,9 +137,9 @@ func RunCosmosRelayerCmd(cmd *cobra.Command, args []string) error {
 	exitSignal := make(chan os.Signal, 1)
 	signal.Notify(exitSignal, syscall.SIGINT, syscall.SIGTERM)
 
+	go proximaXSub.Start(exitSignal)
 	go cosmosSub.Start(exitSignal)
 	<-exitSignal
-
 	return nil
 }
 


### PR DESCRIPTION
Issue: https://github.com/lcnem/proximax-pegzone/issues/28

goleveldbが複数コネクションにサポートしていないため、Relayerのプロセスを一つに統一

Peggyの以下のIssue&PR参考
https://github.com/cosmos/peggy/issues/109
https://github.com/cosmos/peggy/pull/163